### PR TITLE
Added progress bar to Read import

### DIFF
--- a/+seq/FlowCell.m
+++ b/+seq/FlowCell.m
@@ -2,7 +2,7 @@
 # 
 -> seq.Run
 ---
-flow_cell                   : varchar(255)                  # flowcell used on this run
+flowcell                    : varchar(255)                  # flowcell used on this run
 run_date                    : date                          # run date
 %}
 

--- a/+seq/SequencingPrimers.m
+++ b/+seq/SequencingPrimers.m
@@ -1,6 +1,6 @@
 %{
 # 
-primers                     : varchar(30)                   # primers used for sequencing, e.g. Nextera s7+i5
+seq_primers                 : varchar(30)                   # primers used for sequencing, e.g. Nextera s7+i5
 %}
 
 

--- a/pyseq/.gitignore
+++ b/pyseq/.gitignore
@@ -1,1 +1,2 @@
 dj_local_conf.json
+__*

--- a/pyseq/populate.py
+++ b/pyseq/populate.py
@@ -1,0 +1,2 @@
+import seq
+seq.Read().populate()

--- a/pyseq/seq.py
+++ b/pyseq/seq.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 from datetime import datetime
 import itertools
-import tqdm
+from tqdm import tqdm
 import seqbase64
 schema = dj.schema('seq_seq', locals())
 

--- a/pyseq/seq.py
+++ b/pyseq/seq.py
@@ -6,7 +6,6 @@ import re
 import subprocess
 from datetime import datetime
 import itertools
-import random
 import tqdm
 import seqbase64
 schema = dj.schema('seq_seq', locals())
@@ -132,13 +131,10 @@ class Read(dj.Imported):
         chunk = get_chunk()
         with tqdm(total=nreads) as progress:
             while chunk:
-                print('.', end='\n' if random.random() < 0.04 else '', flush=True)
                 self.insert(chunk)
                 chunk = get_chunk()
                 progress.update(chunk_size)
         for f in fids:
             f.close()
-
-
 
 schema.spawn_missing_classes()


### PR DESCRIPTION
To import reads, run
```
python3 populate.py
```
This will output the progress bar with estimated completion time for each lane like this:
```
dimitriv@dna:~/seq/pyseq$ python3 populate.py
DataJoint 0.5.0 (March 8, 2017)
Loading settings from dj_local_conf.json
Please enter DataJoint password: 
Connecting dimitri@datajoint.ninai.org:3306
Importing 247808954 reads
  0%|                                       | 716000/247808954 [02:30<12:44:40, 5381.33it/s]
```

Also, encoded DNA sequences using base64 ASCII encoding